### PR TITLE
Line specific opts

### DIFF
--- a/features/fixtures/quoted-cr-linebrks-crlf-line-endings.csv
+++ b/features/fixtures/quoted-cr-linebrks-crlf-line-endings.csv
@@ -1,0 +1,3 @@
+Short,Multi,Bool
+a,"bc",0
+d,"ef",1

--- a/features/fixtures/quoted-crlf-linebrks-crlf-line-endings.csv
+++ b/features/fixtures/quoted-crlf-linebrks-crlf-line-endings.csv
@@ -1,0 +1,5 @@
+Short,Multi,Bool
+a,"b
+c",0
+d,"e
+f",1

--- a/features/fixtures/quoted-lf-linebrks-crlf-line-endings.csv
+++ b/features/fixtures/quoted-lf-linebrks-crlf-line-endings.csv
@@ -1,0 +1,5 @@
+Short,Multi,Bool
+a,"b
+c",0
+d,"e
+f",1

--- a/features/step_definitions/validation_errors_steps.rb
+++ b/features/step_definitions/validation_errors_steps.rb
@@ -86,5 +86,8 @@ Given(/^I have a CSV that doesn't exist$/) do
 end
 
 Then(/^there should be no "(.*?)" errors$/) do |type|
-  @errors.each { |error| error.type.should_not == type.to_sym }
+  @errors.each { |error|
+    error.type.should_not
+    type.to_sym
+  }
 end

--- a/features/validation_errors.feature
+++ b/features/validation_errors.feature
@@ -145,3 +145,21 @@ Feature: Get validation errors
     And I ask if there are errors
     Then there should be 1 error
     And that error should have the type "line_breaks"
+
+  Scenario: CRLF line breaks inside quotes with CRLF line endings causes no error
+    Given I have a CSV file called "quoted-crlf-linebrks-crlf-line-endings.csv"
+    And it is stored at the url "http://example.com/example1.csv"
+    And I ask if there are errors
+    Then there should be 0 error
+
+  Scenario: LF line breaks inside quotes with CRLF line endings causes no error
+    Given I have a CSV file called "quoted-lf-linebrks-crlf-line-endings.csv"
+    And it is stored at the url "http://example.com/example1.csv"
+    And I ask if there are errors
+    Then there should be 0 error
+
+  Scenario: CR line breaks inside quotes with CRLF line endings causes no error
+    Given I have a CSV file called "quoted-cr-linebrks-crlf-line-endings.csv"
+    And it is stored at the url "http://example.com/example1.csv"
+    And I ask if there are errors
+    Then there should be 0 error

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -217,7 +217,7 @@ module Csvlint
     end
 
     def csv_options_for_line(line)
-      # If a specific row_sep has been explicitly specified, don't mess with it
+      # If a specific row_sep has been explicitly specified, don't mess with it.
       return @csv_options unless @csv_options[:row_sep] == :auto
 
       if line.end_with?("\r\n")

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -184,27 +184,9 @@ module Csvlint
 
       @csv_options[:encoding] = @encoding
 
-      # From CSV.parse_line(stream, **@csv_options), called via inheritance by
-      #   LineCSV.parse_line(stream, **lineopts)
-      #
-      # line = "Short,Multi,Bool\r\n"
-      # options = {:col_sep=>",", :row_sep=>:auto, :quote_char=>"\"",
-      #   :skip_blanks=>false, :encoding=>"UTF-8"}
-      # new(line, **options) = #<Csvlint::Validator::LineCSV io_type:StringIO
-      #   encoding:UTF-8 lineno:0 col_sep:"," row_sep:"\r\n" quote_char:"\"">
-      #
-      # line = "a,\"b\nc\",0\r\n"
-      # options = {:col_sep=>",", :row_sep=>:auto, :quote_char=>"\"",
-      #   :skip_blanks=>false, :encoding=>"UTF-8"}
-      # new(line, **options) = #<Csvlint::Validator::LineCSV io_type:StringIO
-      #   encoding:UTF-8 lineno:0 col_sep:"," row_sep:"\n" quote_char:"\"">
-      #
-      # So, what is setting row_sep incorrectly to "\n" when that character
-      #   appears in quotes, but not at the end of the line?
       begin
-        # lineopts = csv_options_for_line(stream)
-        # row = LineCSV.parse_line(stream, **lineopts)
-        row = LineCSV.parse_line(stream, **@csv_options)
+        lineopts = csv_options_for_line(stream)
+        row = LineCSV.parse_line(stream, **lineopts)
       rescue LineCSV::MalformedCSVError => e
         build_exception_messages(e, stream, current_line) unless e.message.include?("UTF") && @reported_invalid_encoding
       end
@@ -234,19 +216,18 @@ module Csvlint
       @data << row
     end
 
-    # def csv_options_for_line(line)
-    #   # If a specific row_sep has been explicitly specified, don't mess with it
-    #   return @csv_options unless @csv_options[:row_sep] == :auto
+    def csv_options_for_line(line)
+      # If a specific row_sep has been explicitly specified, don't mess with it
+      return @csv_options unless @csv_options[:row_sep] == :auto
 
-    #   # CSV.parse_line does not seem to know how to auto-determine row_sep
-    #   #   from the single line it is given, and throws a MalformedCSVError if
-    #   #   \r\n or \r is present at the end of the line.
-    #   if line.end_with?("\r\n")
-    #     @csv_options.merge({row_sep: "\r\n"})
-    #   else
-    #     @csv_options.merge({row_sep: line[-1, 1]})
-    #   end
-    # end
+      if line.end_with?("\r\n")
+        @csv_options.merge({row_sep: "\r\n"})
+      elsif ["\r", "\n"].include?(line[-1, 1])
+        @csv_options.merge({row_sep: line[-1, 1]})
+      else
+        @csv_options
+      end
+    end
 
     def finish
       sum = @col_counts.inject(:+)

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -184,7 +184,26 @@ module Csvlint
 
       @csv_options[:encoding] = @encoding
 
+      # From CSV.parse_line(stream, **@csv_options), called via inheritance by
+      #   LineCSV.parse_line(stream, **lineopts)
+      #
+      # line = "Short,Multi,Bool\r\n"
+      # options = {:col_sep=>",", :row_sep=>:auto, :quote_char=>"\"",
+      #   :skip_blanks=>false, :encoding=>"UTF-8"}
+      # new(line, **options) = #<Csvlint::Validator::LineCSV io_type:StringIO
+      #   encoding:UTF-8 lineno:0 col_sep:"," row_sep:"\r\n" quote_char:"\"">
+      #
+      # line = "a,\"b\nc\",0\r\n"
+      # options = {:col_sep=>",", :row_sep=>:auto, :quote_char=>"\"",
+      #   :skip_blanks=>false, :encoding=>"UTF-8"}
+      # new(line, **options) = #<Csvlint::Validator::LineCSV io_type:StringIO
+      #   encoding:UTF-8 lineno:0 col_sep:"," row_sep:"\n" quote_char:"\"">
+      #
+      # So, what is setting row_sep incorrectly to "\n" when that character
+      #   appears in quotes, but not at the end of the line?
       begin
+        # lineopts = csv_options_for_line(stream)
+        # row = LineCSV.parse_line(stream, **lineopts)
         row = LineCSV.parse_line(stream, **@csv_options)
       rescue LineCSV::MalformedCSVError => e
         build_exception_messages(e, stream, current_line) unless e.message.include?("UTF") && @reported_invalid_encoding
@@ -214,6 +233,20 @@ module Csvlint
       end
       @data << row
     end
+
+    # def csv_options_for_line(line)
+    #   # If a specific row_sep has been explicitly specified, don't mess with it
+    #   return @csv_options unless @csv_options[:row_sep] == :auto
+
+    #   # CSV.parse_line does not seem to know how to auto-determine row_sep
+    #   #   from the single line it is given, and throws a MalformedCSVError if
+    #   #   \r\n or \r is present at the end of the line.
+    #   if line.end_with?("\r\n")
+    #     @csv_options.merge({row_sep: "\r\n"})
+    #   else
+    #     @csv_options.merge({row_sep: line[-1, 1]})
+    #   end
+    # end
 
     def finish
       sum = @col_counts.inject(:+)

--- a/lib/csvlint/version.rb
+++ b/lib/csvlint/version.rb
@@ -1,3 +1,3 @@
 module Csvlint
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end


### PR DESCRIPTION
My preferred approach to solving Data-Liberation-Front/csvlint.rb#198

This issue is caused by mixed EOL indicators used in the same file. 

The usual pattern we see[^1], is CRLF (\r\n) at the end of actual CSV rows, but just LF (\n) used inside quoted text field values.

To validate a CSV, csvlint.rb currently does the following: 

* `Validator.parse_line` goes through the file line-by-line, looking for overall invalid encoding. Notably, this keeps track of quotes in order to join multiple lines where the line breaks occur inside quotes. The issues in question are usually not found in this process. The line it passes to `validate_line` is usually the whole, correctly joined line.
* `Validator.validate_line` calls `Validator.parse_contents` on the line
* `Validator.parse_contents` calls `LineCSV.parse_line` (LineCSV is a subclass of the standard CSV library) with the same `@csv_options` derived from the dialect passed to  `Csvlint::Validator`. If no "lineTerminator" (mapped to `csv_options[:row_sep]`) value is not explicitly given in the dialect specification, it gets set by Csvlint to `:auto`.
* While calling `CSV.parse` on the whole file with `row_sep: :auto` generally works due to the parser making use of the context of the full file, calling `parse_line` with `row_sep: :auto` blows up because the parser assumes the first EOL it hits is the real one or something. 

So, to fix this: 

* Before we call `LineCSV.parse_line`, we check the `csv_options[:row_sep]` value. 
* If it is NOT `:auto`, we pass it through as `csv_options_for_line`. 
* Otherwise we check the actual end of the line we are about to pass through. If the full line ends with `\r\n`, `\r`, or `\n`, we merge that string into the `@csv_options` instance variable as the new, explicit `:row_sep` value. (So, on subsequent lines, we pass the no-longer-auto-row_sep @csv_options through -- better for performance, AND we'll likely hear about it if any subsequent lines don't end with the `:row_sep` value.)


[^1]: Because it's how CollectionSpace usually exports data containing line breaks entered by Windows users, who export data for data round-tripping via the CSV Importer, which uses csvlint.rb for CSV validation, and it currently can't handle this. [RFC 4180](http://www.ietf.org/rfc/rfc4180.txt) prescribes CRLF EOLs, but entering data inside a field in the CollectionSpace UI appears to enter just LF, and that's what comes out in the quoted text.
