### PR TITLE
Fix row_count always being 1 when \r used as lineTerminator

### DIFF
--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -608,6 +608,64 @@ describe Csvlint::Validator do
     end
   end
 
+  describe "#row_count" do
+    let(:validator) { Csvlint::Validator.new(StringIO.new(csv), opts) }
+    let(:opts) { {} }
+    let(:result) { validator.row_count }
+
+    context 'with \r\n line terminators and final EOL' do
+      let(:csv) do
+        %("Foo","Bar","Baz"\r\n"1","2","3"\r\n"3","2","1"\r\n)
+      end
+
+      it "should count the total number of rows read" do
+        expect(validator.row_count).to eq(3)
+      end
+    end
+
+    context 'with \r\n line terminators and without final EOL' do
+      let(:csv) do
+        %("Foo","Bar","Baz"\r\n"1","2","3"\r\n"3","2","1")
+      end
+
+      it "should count the total number of rows read" do
+        expect(validator.row_count).to eq(3)
+      end
+    end
+
+    context 'with \n line terminators and final EOL' do
+      let(:csv) do
+        %("Foo","Bar","Baz"\n"1","2","3"\n"3","2","1"\n)
+      end
+
+      it "should count the total number of rows read" do
+        expect(validator.row_count).to eq(3)
+      end
+    end
+
+    context 'with \r line terminators and final EOL' do
+      let(:csv) do
+        %("Foo","Bar","Baz"\r"1","2","3"\r"3","2","1"\r)
+      end
+
+      it "should count the total number of rows read" do
+        expect(validator.row_count).to eq(3)
+      end
+    end
+
+    context 'with \r line terminators and final EOL and lineTerminator ' \
+      "specified" do
+      let(:csv) do
+        %("Foo","Bar","Baz"\r"1","2","3"\r"3","2","1"\r)
+      end
+      let(:opts) { {"lineTerminator" => "\r"} }
+
+      it "should count the total number of rows read" do
+        expect(validator.row_count).to eq(3)
+      end
+    end
+  end
+
   # Commented out because there is currently no way to mock redirects with Typhoeus and WebMock - see https://github.com/bblimke/webmock/issues/237
   # it "should follow redirects to SSL" do
   #   stub_request(:get, "http://example.com/redirect").to_return(:status => 301, :headers=>{"Location" => "https://example.com/example.csv"})


### PR DESCRIPTION
This PR fixes the fact that row_count was always reported as 1 for CSVs using `\r` as lineTerminator, even if the dialect explicitly set lineTerminator to `\r`. 

The cause of this issue was the use of `#each_line` method to split streams/files into lines sent to `#parse_line`. With no arguments given, `#each_line`reads lines as determined by line separator `$/`.[^1] By default, `$/` is set to `\n`.[^2]

This results in the entire stream/file being sent to `#parse_line`, which was explicitly only treating `\n` as a line break. 

This was fixed by: 

1. Making all places that checked for line breaks by matching only on `\n` check for **either** `\n` or `\r`

2. Deriving the correct `$/` value prior to calling `#each_line`, and then resetting `$/` to the default value after the `#each_line` block is closed.  

The latter is currently accomplished by:

* Using the dialect lineTerminator value if set to an actual String value (e.g. not :auto)
* Otherwise, get the entire `@source` as a String. If this includes `\n`, set `$/` to `\n`. Otherwise, set it to `\r`

The second step has 2 problems: 

* Performance on gigantic files
* Potential to blow up or cause other problems if a quoted field value contains `\n` or `\r\n`, but the file's actual lineTerminator is `\r`

I am going ahead with this implementation for now because: 

* Our use case generally should not involve CSV so large that the first is an issue
* The second just opens up an abyss of pain for a somewhat unlikely use case **that isn't working correctly prior to this change, either**

I have an idea for an approach that would address both of those issues, but it gets me halfway to writing a CSV parser from scratch and I ain't got time for that at the moment.  
[^1]: https://docs.ruby-lang.org/en/master/IO.html#method-i-each_line
[^2]: https://docs.ruby-lang.org/en/master/globals_rdoc.html#label-24-2F+-28Input+Record+Separator-29